### PR TITLE
fix: typo

### DIFF
--- a/1.1-lead-role.md
+++ b/1.1-lead-role.md
@@ -2,7 +2,7 @@
 
 The work you’ll do as a Study Group lead will ramp up slowly, because most groups start small. Your tasks will change over time as your group grows and changes. As Study Group Lead, you’ll do a mix of the following tasks:
 
-* **Outreach and communications**, as you find your first few members and getabout the group, and as you publicize each of the group’s meetings and events;
+* **Outreach and communications**, as you find your first few members and get about the group, and as you publicize each of the group’s meetings and events;
 * **Logistics and event coordination**, as you organize group meetings and events;
 * **Strategy and planning**, as you create a schedule and plan for your group over a semester or year, and tweak that plan to respond to the needs of your group;
 * **Teaching**, as you prepare some of the materials and facilitate skill-sharing sessions for your group;


### PR DESCRIPTION
Just fixing a typo in the following text: "Outreach and communications, as you find your first few members and getabout the group, and as you publicize each of the group’s meetings and events;"